### PR TITLE
ci: security hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,68 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+# Workflow-level least-privilege: read-only by default
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: stable
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+
+      - name: Build (default features)
+        run: cargo build --locked
+
+      - name: Build (all features)
+        run: cargo build --locked --all-features
+
+      - name: Run tests
+        run: cargo test --locked
+
+      - name: Run tests (all features)
+        run: cargo test --locked --all-features
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: stable
+          components: clippy, rustfmt
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+
+      - name: Check formatting
+        run: cargo fmt -- --check
+
+      - name: Clippy (default features)
+        run: cargo clippy --locked -- -D warnings
+
+      - name: Clippy (all features)
+        run: cargo clippy --locked --all-features -- -D warnings


### PR DESCRIPTION
## Summary

This PR introduces `.github/workflows/ci.yml` — the first custom CI workflow for this repository — with all security hardening controls applied from inception. There were no pre-existing workflow files to patch; the only workflows present were GitHub-managed dynamic ones (Copilot review and Dependabot).

## What was fixed / hardened

### 1. SHA-pinned external actions
All third-party actions are pinned to immutable commit SHAs with the human-readable tag preserved as an inline comment:

| Action | Tag | Pinned SHA |
|---|---|---|
| `actions/checkout` | v4 | `34e114876b0b11c390a56381ad16ebd13914f8d5` |
| `dtolnay/rust-toolchain` | v1 | `e97e2d8cc328f1b50210efc529dca0028893a2d9` |
| `Swatinem/rust-cache` | v2.9.1 | `c19371144df3bb44fab255c43d04cbc2ab54d1c4` |

All pinned tags were verified to be current/supported releases (not deprecated or yanked).

### 2. Least-privilege permissions
`permissions: contents: read` is set at the workflow level. No job requires elevated permissions (no git push, no OIDC token needed), so no job-level overrides are necessary.

### 3. `persist-credentials: false`
Applied to every `actions/checkout` step. Neither job writes back to git, so credentials are not needed beyond the initial fetch.

### 4. Template injection
No `run:` blocks reference `${{ github.* }}` or other workflow expressions — no injection risk present.

### 5. No npm/pip setup
No `actions/setup-node` or `actions/setup-python` steps are used (this is a pure Rust crate), so the `aikidosec-safe-chain` insertion rule does not apply.

### 6. No duplicate setup sequences
Only two jobs (`test`, `lint`) with slightly different `components:` needs — no composite action extraction is warranted.

## Intentionally not applied

- **`unpinned-uses` on `aptos-labs/*` actions** — internal Aptos actions are never SHA-pinned by policy (they use `@main`). No internal actions are referenced in this workflow.
- **`artipacked` exemption** — not applicable; neither job pushes back to git, so `persist-credentials: false` is applied unconditionally.

## Zizmor result

Running `zizmor --format sarif .github/` against the new workflow returns **zero findings**.